### PR TITLE
Remove _resource

### DIFF
--- a/lib/dog_biscuits.rb
+++ b/lib/dog_biscuits.rb
@@ -224,6 +224,7 @@ module DogBiscuits
   end
 
   autoload_under 'models/concerns/metadata_properties/marc_relators' do
+    autoload :Advisor
     autoload :Funder
     autoload :Editor
     autoload :PlaceOfPublication
@@ -277,7 +278,6 @@ module DogBiscuits
   end
 
   autoload_under 'models/concerns/metadata_properties/uketd' do
-    autoload :Advisor
     autoload :DateOfAward
     autoload :Qualification
   end

--- a/lib/dog_biscuits/configuration.rb
+++ b/lib/dog_biscuits/configuration.rb
@@ -68,10 +68,9 @@ module DogBiscuits
 
     # Common properties from DogBiscuits atop those in BasicMetadata
     # Also include resource_type which is part of BasicMetadata but not part of the Hyrax WorkForm
-    # omitting _resource properties (managing_organisation_, department_, funder_, _output_of)
     # omitting date as this is used for faceting only
     def common_properties
-      %i[department doi former_identifier note output_of lat long alt location].freeze
+      %i[department doi former_identifier note output_of lat long alt location managing_organisation funder].freeze
     end
 
     # Add values that aren't found in the following table-based authorities to be added on save.
@@ -88,7 +87,6 @@ module DogBiscuits
     # The existing fields will be replaced:
     #   resource_type, creator, tag, subject, language, based_near_label, publisher, file_format
     attr_writer :facet_properties
-    # omitting funder
     def facet_properties
       @facet_properties ||= %i[
         human_readable_type
@@ -98,6 +96,7 @@ module DogBiscuits
         contributor_type
         publisher
         department
+        funder
         date
         keyword
         subject
@@ -350,11 +349,12 @@ module DogBiscuits
     end
 
     attr_writer :thesis_properties
-    # omitting awarding_institution_resource orcid
+    # omitting orcid
     def thesis_properties
       properties = %i[abstract
                       advisor
                       date_of_award
+                      awarding_institution
                       qualification_level
                       qualification_name]
       properties = base_properties + properties + common_properties
@@ -407,7 +407,6 @@ module DogBiscuits
         dc_access_rights
         dc_format
         extent
-        funder
         has_restriction
         last_access
         number_of_downloads

--- a/lib/dog_biscuits/indexers/collection_indexer.rb
+++ b/lib/dog_biscuits/indexers/collection_indexer.rb
@@ -4,19 +4,6 @@ module DogBiscuits
   class CollectionIndexer < Hyrax::CollectionIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add all properties called *_resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in solr
-    # Method must exist, but can return an empty array
-    def labels_to_index
-      ['creator']
-    end
-
-    # Add any properties to ensure they are 'mixed in' with the *_labels field in solr
-    # Method must exist, but can return an empty array
-    def strings_to_index
-      ['creator']
-    end
-
     # Add any custom indexing into here. Method must exist, but can be empty.
     def do_local_indexing(solr_doc); end
   end

--- a/lib/dog_biscuits/indexers/concerns/indexes_common.rb
+++ b/lib/dog_biscuits/indexers/concerns/indexes_common.rb
@@ -2,61 +2,12 @@
 
 module DogBiscuits
   module IndexesCommon
-    attr_accessor :strings_to_index, :labels_to_index
 
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc_for_labels(solr_doc)
-        solr_doc_for_strings(solr_doc)
         solr_doc_for_contributors(solr_doc)
         solr_doc_for_dates(solr_doc)
         do_local_indexing(solr_doc)
-      end
-    end
-
-    # Index resource fields into the _label field
-    def solr_doc_for_labels(solr_doc)
-      # Index preflabel and altlabels into solr for _resource HABMs.
-      labels_to_index.each do |v|
-        method = "#{v}_resource"
-
-        # HABMs are indexed as predicate name, so index them as property name
-        solr_doc["#{v}_resource_ssim"] = object.send(method).collect(&:id)
-
-        # Remove existing indexing remove any potential conflicts with strings
-        solr_doc.delete("#{v}_ssim")
-
-        prefs = object.send(method).collect(&:preflabel)
-
-        # Create a new array
-
-        solr_doc[Solrizer.solr_name("#{v}_label", :stored_searchable)] = prefs if prefs.present?
-        solr_doc[Solrizer.solr_name("#{v}_label", :facetable)] = prefs if prefs.present?
-
-        alts = object.send(method).collect(&:altlabel).to_a.flatten!
-        solr_doc["#{v}_label_alt_tesim"] = alts if alts.present?
-
-        # This field is used for upating usages when an authority changes or is destroyed.
-        solr_doc['values_tesim'] = object.send(method).collect(&:id)
-      end
-    end
-
-    # Index string fields into the _label field
-    def solr_doc_for_strings(solr_doc)
-      strings_to_index.each do |v|
-        strings = object.send(v).to_a
-        # This will replace the field, thus getting rid of any indexing conflicts with HABM
-        solr_doc[Solrizer.solr_name(v, :stored_searchable)] = strings
-        solr_doc[Solrizer.solr_name(v, :facetable)] = strings
-
-        # If there is anything in the solr_doc, add to it
-        if solr_doc["#{v}_label_tesim"]
-          solr_doc[Solrizer.solr_name("#{v}_label", :stored_searchable)].push(*strings).uniq!
-          solr_doc[Solrizer.solr_name("#{v}_label", :facetable)].push(*strings).uniq!
-        else
-          solr_doc[Solrizer.solr_name("#{v}_label", :stored_searchable)] = strings
-          solr_doc[Solrizer.solr_name("#{v}_label", :facetable)] = strings
-        end
       end
     end
 

--- a/lib/dog_biscuits/indexers/concerns/indexes_common.rb
+++ b/lib/dog_biscuits/indexers/concerns/indexes_common.rb
@@ -2,7 +2,6 @@
 
 module DogBiscuits
   module IndexesCommon
-
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc_for_contributors(solr_doc)
@@ -19,7 +18,6 @@ module DogBiscuits
       if respond_to? :contributors_to_index
         contributors_to_index.each do |v|
           labels = object.send(v).to_a
-          labels.push(*object.send("#{v}_resource").collect(&:preflabel))
           # If there is anything in the solr_doc, add to it
           if solr_doc["contributor_combined_tesim"]
             solr_doc[Solrizer.solr_name("contributor_combined", :stored_searchable)].push(*labels).uniq!
@@ -28,7 +26,7 @@ module DogBiscuits
             solr_doc[Solrizer.solr_name("contributor_combined", :stored_searchable)] = labels
             solr_doc[Solrizer.solr_name("contributor_combined", :facetable)] = labels
           end
-          # I don't think the logic is quite right here as there will only ever be one result
+          # @todo I don't think the logic is quite right here as there will only ever be one result
           labels.each do |_label|
             if solr_doc['contributor_type_sim']
               solr_doc[Solrizer.solr_name("contributor_type", :facetable)] << v

--- a/lib/dog_biscuits/indexers/conference_item_indexer.rb
+++ b/lib/dog_biscuits/indexers/conference_item_indexer.rb
@@ -4,20 +4,9 @@ module DogBiscuits
   class ConferenceItemIndexer < Hyrax::WorkIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add *all* properties called _resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in the _label solr field
-    def labels_to_index
-      ['creator', 'editor', 'managing_organisation', 'presented_at']
-    end
-
-    # Add string properties that have a parallel _resource property to ensure they are mixed into the _label solr field
-    def strings_to_index
-      ['creator', 'editor', 'presented_at']
-    end
-
     # NB. include 'contributor' here if it is used in the form
     def contributors_to_index
-      ['editor']
+      ['editor', 'funder']
     end
 
     # Add any custom indexing into here. Method must exist, but can be empty.

--- a/lib/dog_biscuits/indexers/dataset_indexer.rb
+++ b/lib/dog_biscuits/indexers/dataset_indexer.rb
@@ -4,21 +4,8 @@ module DogBiscuits
   class DatasetIndexer < Hyrax::WorkIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add all properties called *_resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in solr
-    # Method must exist, but can return an empty array
-    def labels_to_index
-      ['creator', 'output_of']
-    end
-
-    # Add any properties to ensure they are 'mixed in' with the *_labels field in solr
-    # Method must exist, but can return an empty array
-    def strings_to_index
-      ['creator', 'output_of']
-    end
-
     def contributors_to_index
-      []
+      ['funder']
     end
 
     # Force the type of certain indexed fields in solr
@@ -33,21 +20,7 @@ module DogBiscuits
     #   on text fields it's case-insensitive)
     def do_local_indexing(solr_doc)
       solr_doc['dc_access_rights_tesi'] = object.dc_access_rights.collect { |x| x }
-      # index file_format - doesn't work cos it saves and causes error in AttachFilesToWorkJob
-      # solr_doc['file_format_tesim'] = object.members.collect { |f| file_format(f) }
-      # solr_doc['file_format_sim'] = object.members.collect { |f| file_format(f) }
     end
 
-    # private
-
-    # def file_format(fileset)
-    #   if fileset.mime_type.present? && fileset.format_label.present?
-    #     "#{fileset.mime_type.split('/').last} (#{fileset.format_label.join(', ')})"
-    #   elsif fileset.mime_type.present?
-    #     fileset.mime_type.split('/').last
-    #   elsif fileset.format_label.present?
-    #     fileset.format_label
-    #   end
-    # end
   end
 end

--- a/lib/dog_biscuits/indexers/dataset_indexer.rb
+++ b/lib/dog_biscuits/indexers/dataset_indexer.rb
@@ -21,6 +21,5 @@ module DogBiscuits
     def do_local_indexing(solr_doc)
       solr_doc['dc_access_rights_tesi'] = object.dc_access_rights.collect { |x| x }
     end
-
   end
 end

--- a/lib/dog_biscuits/indexers/digital_archival_object_indexer.rb
+++ b/lib/dog_biscuits/indexers/digital_archival_object_indexer.rb
@@ -4,19 +4,6 @@ module DogBiscuits
   class DigitalArchivalObjectIndexer < Hyrax::WorkIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add *all* properties called _resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in the _label solr field
-    # Method must exist, but can return an empty array
-    def labels_to_index
-      ['creator']
-    end
-
-    # Add string properties that have a parallel _resource property to ensure they are mixed into the _label solr field
-    # Method must exist, but can return an empty array
-    def strings_to_index
-      ['creator', 'access_provided_by']
-    end
-
     def contributors_to_index
       []
     end

--- a/lib/dog_biscuits/indexers/exam_paper_indexer.rb
+++ b/lib/dog_biscuits/indexers/exam_paper_indexer.rb
@@ -4,19 +4,6 @@ module DogBiscuits
   class ExamPaperIndexer < Hyrax::WorkIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add all properties called *_resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in solr
-    # Method must exist, but can return an empty array
-    def labels_to_index
-      ['creator', 'managing_organisation']
-    end
-
-    # Add any properties to ensure they are 'mixed in' with the *_labels field in solr
-    # Method must exist, but can return an empty array
-    def strings_to_index
-      ['creator']
-    end
-
     # Add any custom indexing into here. Method must exist, but can be empty.
     def do_local_indexing(solr_doc); end
   end

--- a/lib/dog_biscuits/indexers/journal_article_indexer.rb
+++ b/lib/dog_biscuits/indexers/journal_article_indexer.rb
@@ -4,15 +4,9 @@ module DogBiscuits
   class JournalArticleIndexer < Hyrax::WorkIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add all properties called *_resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in solr
-    def labels_to_index
-      ['creator', 'output_of', 'managing_organisation', 'department']
-    end
-
     # Add any properties to ensure they are 'mixed in' with the *_labels field in solr
-    def strings_to_index
-      ['creator']
+    def contributors_to_index
+      ['editor', 'funder']
     end
 
     # Add any custom indexing into here. Method must exist, but can be empty.

--- a/lib/dog_biscuits/indexers/journal_article_indexer.rb
+++ b/lib/dog_biscuits/indexers/journal_article_indexer.rb
@@ -6,7 +6,7 @@ module DogBiscuits
 
     # Add any properties to ensure they are 'mixed in' with the *_labels field in solr
     def contributors_to_index
-      ['editor', 'funder']
+      ['funder']
     end
 
     # Add any custom indexing into here. Method must exist, but can be empty.

--- a/lib/dog_biscuits/indexers/package_indexer.rb
+++ b/lib/dog_biscuits/indexers/package_indexer.rb
@@ -4,17 +4,6 @@ module DogBiscuits
   class PackageIndexer < Hyrax::WorkIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add *all* properties called _resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in the _label solr field
-    def labels_to_index
-      []
-    end
-
-    # Add string properties that have a parallel _resource property to ensure they are mixed into the _label solr field
-    def strings_to_index
-      []
-    end
-
     # NB. include 'contributor' here if it is used in the form
     def contributors_to_index
       []

--- a/lib/dog_biscuits/indexers/published_work_indexer.rb
+++ b/lib/dog_biscuits/indexers/published_work_indexer.rb
@@ -4,19 +4,8 @@ module DogBiscuits
   class PublishedWorkIndexer < Hyrax::WorkIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add all properties called *_resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in solr
-    def labels_to_index
-      ['creator', 'editor', 'contributor', 'managing_organisation']
-    end
-
-    # Add any properties to ensure they are 'mixed in' with the *_labels field in solr
-    def strings_to_index
-      ['creator', 'editor', 'contributor']
-    end
-
     def contributors_to_index
-      ['editor']
+      ['editor', 'funder']
     end
 
     # Add any custom indexing into here. Method must exist, but can be empty.

--- a/lib/dog_biscuits/indexers/thesis_indexer.rb
+++ b/lib/dog_biscuits/indexers/thesis_indexer.rb
@@ -4,21 +4,8 @@ module DogBiscuits
   class ThesisIndexer < Hyrax::WorkIndexer
     include DogBiscuits::IndexesCommon
 
-    # Add *all* properties called _resource to ensure the preflabel and altlabel of the related object
-    #   are indexed in the _label solr field
-    # Method must exist, but can return an empty array
-    def labels_to_index
-      ['creator', 'advisor', 'department', 'awarding_institution', 'managing_organisation']
-    end
-
-    # Add string properties that have a parallel _resource property to ensure they are mixed into the _label solr field
-    # Method must exist, but can return an empty array
-    def strings_to_index
-      ['creator', 'advisor']
-    end
-
     def contributors_to_index
-      ['advisor']
+      ['advisor', 'funder']
     end
 
     # Add any custom indexing into here. Method must exist, but can be empty.

--- a/lib/dog_biscuits/models/authority.rb
+++ b/lib/dog_biscuits/models/authority.rb
@@ -8,8 +8,6 @@ module DogBiscuits
     include DogBiscuits::ValidateLabel
 
     before_save :add_label
-    after_save :update_usages
-    after_destroy :update_usages
 
     belongs_to :concept_scheme,
                class_name: 'DogBiscuits::ConceptScheme',
@@ -33,30 +31,6 @@ module DogBiscuits
 
     def edit_groups
       ['admin']
-    end
-
-    # Find any objects that use the authority term being updated or destroyed
-    #   run a solr update on each object.
-    def update_usages
-      num = num_usages.to_i
-      unless num.nil? || num.zero?
-        ActiveFedora::SolrService.get(
-          "values_tesim:#{id}",
-          fl: 'id',
-          rows: num
-        )['response']['docs'].each do |r|
-          ActiveFedora::Base.find(r['id']).update_index
-        end
-      end
-    end
-
-    # Get the number of objects to update.
-    def num_usages
-      ActiveFedora::SolrService.get(
-        "values_tesim:#{id}",
-        fl: 'id',
-        rows: 0
-      )['response']['numResults']
     end
 
     # Ensure rdfs label and pref label and the same. Prefer preflabel.

--- a/lib/dog_biscuits/models/concerns/extended_solr_document.rb
+++ b/lib/dog_biscuits/models/concerns/extended_solr_document.rb
@@ -48,7 +48,6 @@ module DogBiscuits
     end
 
     # TODO: dates
-    # TODO sort out the _label ones ... those below are _resource only
 
     # Keep these alphebetized; comments indicate those in basic_metadata
     #   see https://github.com/samvera/hyrax/blob/master/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -57,13 +56,11 @@ module DogBiscuits
       attribute :access_provided_by, Solr::Array, solr_name('access_provided_by')
       attribute :advisor, Solr::Array, solr_name('advisor')
       attribute :alt, Solr::Array, solr_name('alt')
-      attribute :awarding_institution, Solr::Array, solr_name('awarding_institution_label')
-      # based_near and based_near_label
+      attribute :awarding_institution, Solr::Array, solr_name('awarding_institution')
+      # based_near and based_near
       attribute :content_version, Solr::Array, solr_name('content_version')
       # contributor
       # creator
-      # creator is used by other models so we need to distinguish _label
-      # attribute :creator_label, Solr::Array, solr_name('creator_label')
       attribute :date, Solr::Array, solr_name('date')
       attribute :date_accepted, Solr::Array, solr_name('date_accepted')
       attribute :date_available, Solr::Array, solr_name('date_available')
@@ -102,7 +99,7 @@ module DogBiscuits
       # license
       attribute :location, Solr::Array, solr_name('location')
       attribute :long, Solr::Array, solr_name('long')
-      attribute :managing_organisation, Solr::Array, solr_name('managing_organisation_label')
+      attribute :managing_organisation, Solr::Array, solr_name('managing_organisation')
       attribute :module_code, Solr::Array, solr_name('module_code')
       attribute :note, Solr::Array, solr_name('note')
       attribute :number_of_downloads, Solr::Array, solr_name('last_access')
@@ -116,7 +113,7 @@ module DogBiscuits
       attribute :place_of_publication, Solr::Array, solr_name('place_of_publication')
       attribute :presented_at, Solr::Array, solr_name('presented_at')
       attribute :part_of, Solr::Array, solr_name('part_of')
-      attribute :project, Solr::Array, solr_name('project_label')
+      attribute :project, Solr::Array, solr_name('project')
       attribute :publication_status, Solr::Array, solr_name('publication_status')
       # publisher
       attribute :qualification_level, Solr::Array, solr_name('qualification_level')

--- a/lib/dog_biscuits/models/concerns/metadata_properties/bibframe/awarding_institution.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/bibframe/awarding_institution.rb
@@ -5,9 +5,9 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      has_and_belongs_to_many :awarding_institution_resource,
-                              class_name: 'DogBiscuits::Organisation',
-                              predicate: ::RDF::Vocab::BF2.grantingInstitution
+      property :awarding_institution, predicate: ::RDF::Vocab::BF2.grantingInstitution.fnd do |index|
+        index.as :stored_searchable, :facetable
+      end
     end
   end
 end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/bibframe/awarding_institution.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/bibframe/awarding_institution.rb
@@ -5,7 +5,7 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      property :awarding_institution, predicate: ::RDF::Vocab::BF2.grantingInstitution.fnd do |index|
+      property :awarding_institution, predicate: ::RDF::Vocab::BF2.grantingInstitution do |index|
         index.as :stored_searchable, :facetable
       end
     end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/bibo/presented_at.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/bibo/presented_at.rb
@@ -5,12 +5,8 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      # TODO: Event
-      has_and_belongs_to_many :presented_at_resource,
-                              class_name: DogBiscuits::Authority,
-                              predicate: ::RDF::Vocab::BIBO.presentedAt
-
-      property :presented_at, predicate: DogBiscuits::Vocab::UlccTerms.presentedAtConference do |index|
+      # @todo this could be an event resource
+      property :presented_at, predicate: ::RDF::Vocab::BIBO.presentedAt do |index|
         index.as :stored_searchable, :facetable
       end
     end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/dc/contributor.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/dc/contributor.rb
@@ -5,12 +5,7 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      # use MARCRelator instead of dc.contributor to avoid solr conflict
-      has_and_belongs_to_many :contributor_resource,
-                              # predicate: ::RDF::Vocab::DC.contributor
-                              predicate: ::RDF::Vocab::MARCRelators.ctb,
-                              class_name: 'DogBiscuits::Agent'
-
+      # alternative predicate ::RDF::Vocab::MARCRelators.ctb
       property :contributor, predicate: ::RDF::Vocab::DC11.contributor do |index|
         index.as :stored_searchable, :sortable, :facetable
       end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/dc/creator.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/dc/creator.rb
@@ -5,14 +5,7 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      # use MARCRelator instead of dc.creator to avoid solr conflict with creator property
-      # For HABM, 'creator_resource' isn't used for solr indexing, the predicate name is
-      #   this is inconsistent
-      has_and_belongs_to_many :creator_resource,
-                              # predicate: ::RDF::Vocab::DC.creator,
-                              predicate: ::RDF::Vocab::MARCRelators.cre,
-                              class_name: 'DogBiscuits::Agent'
-
+      # alternative predicate ::RDF::Vocab::MARCRelators.cre
       property :creator, predicate: ::RDF::Vocab::DC11.creator do |index|
         index.as :stored_searchable, :sortable, :facetable
       end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/dc/publisher.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/dc/publisher.rb
@@ -5,11 +5,7 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      has_and_belongs_to_many :publisher_resource,
-                              class_name: 'DogBiscuits::Agent',
-                              # predicate: ::RDF::Vocab::DC.publisher
-                              predicate: ::RDF::Vocab::MARCRelators.pbl
-
+      # alternative predicate ::RDF::Vocab::MARCRelators.pbl
       property :publisher, predicate: ::RDF::Vocab::DC11.publisher do |index|
         index.as :stored_searchable, :sortable, :facetable
       end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/dc/subject.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/dc/subject.rb
@@ -5,15 +5,6 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      # Controlled Subjects from internal schemes
-      # MODS:subjectTopic is used instead of dc:subject to avoid clash with 'subject':
-      #   HABMs are added to solr with the predicate name (subjectTopic) rather than the relation name (subject_resource)
-      #   FOAF.topic would be an alternative
-      # has_and_belongs_to_many :subject_resource,
-      #                         class_name: 'DogBiscuits::Concept',
-      #                         # predicate: ::RDF::Vocab::DC.subject
-      #                         predicate: ::RDF::Vocab::DC.subject
-
       property :subject, predicate: ::RDF::Vocab::DC11.subject do |index|
         index.as :stored_searchable, :facetable
       end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/marc_relators/advisor.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/marc_relators/advisor.rb
@@ -6,7 +6,7 @@ module DogBiscuits
 
     included do
       # alternative (local) predicate DogBiscuits::Vocab::Uketd.advisor
-      property :advisor, predicate: DogBiscuits::Vocab::Uketd.advisor do |index|
+      property :advisor, predicate: ::RDF::Vocab::MARCRelators.ths do |index|
         index.as :stored_searchable, :facetable
       end
     end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/marc_relators/editor.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/marc_relators/editor.rb
@@ -5,11 +5,8 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      has_and_belongs_to_many :editor_resource,
-                              class_name: 'DogBiscuits::Agent',
-                              predicate: ::RDF::Vocab::MARCRelators.edc
-
-      property :editor, predicate: ::RDF::Vocab::BIBO.editor do |index|
+      # alternative predicate ::RDF::Vocab::BIBO.editor
+      property :editor, predicate: ::RDF::Vocab::MARCRelators.edc do |index|
         index.as :stored_searchable, :facetable
       end
     end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/marc_relators/funder.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/marc_relators/funder.rb
@@ -5,10 +5,6 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      has_and_belongs_to_many :funder_resource,
-                              class_name: 'DogBiscuits::Agent',
-                              predicate: ::RDF::Vocab::MARCRelators.fnd
-
       property :funder, predicate: ::RDF::Vocab::MARCRelators.fnd do |index|
         index.as :stored_searchable, :facetable
       end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/pure/managing_organisation.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/pure/managing_organisation.rb
@@ -5,10 +5,10 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      has_and_belongs_to_many :managing_organisation_resource,
-                              class_name: 'DogBiscuits::Organisation',
-                              predicate:
-                                  DogBiscuits::Vocab::PureTerms.pureManagingUnit
+      property :managing_organisation,
+          predicate: DogBiscuits::Vocab::PureTerms.pureManagingUnit do |index|
+            index.as :stored_searchable, :facetable
+      end
     end
   end
 end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/pure/managing_organisation.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/pure/managing_organisation.rb
@@ -6,8 +6,8 @@ module DogBiscuits
 
     included do
       property :managing_organisation,
-          predicate: DogBiscuits::Vocab::PureTerms.pureManagingUnit do |index|
-            index.as :stored_searchable, :facetable
+               predicate: DogBiscuits::Vocab::PureTerms.pureManagingUnit do |index|
+        index.as :stored_searchable, :facetable
       end
     end
   end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/schema/department.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/schema/department.rb
@@ -5,10 +5,6 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      has_and_belongs_to_many :department_resource,
-                              class_name: 'DogBiscuits::Organisation',
-                              predicate: ::RDF::URI.new('http://dlib.york.ac.uk/ontologies/uketd#departmentResource')
-
       property :department, predicate: ::RDF::Vocab::SCHEMA.department do |index|
         index.as :stored_searchable, :facetable
       end

--- a/lib/dog_biscuits/models/concerns/metadata_properties/uketd/advisor.rb
+++ b/lib/dog_biscuits/models/concerns/metadata_properties/uketd/advisor.rb
@@ -5,10 +5,7 @@ module DogBiscuits
     extend ActiveSupport::Concern
 
     included do
-      has_and_belongs_to_many :advisor_resource,
-                              class_name: 'DogBiscuits::Agent',
-                              predicate: ::RDF::Vocab::MARCRelators.ths
-
+      # alternative (local) predicate DogBiscuits::Vocab::Uketd.advisor
       property :advisor, predicate: DogBiscuits::Vocab::Uketd.advisor do |index|
         index.as :stored_searchable, :facetable
       end

--- a/lib/dog_biscuits/property_mappings/property_mappings.rb
+++ b/lib/dog_biscuits/property_mappings/property_mappings.rb
@@ -82,6 +82,10 @@ module DogBiscuits
             index: "('alt', :stored_searchable)",
             label: 'Altitude'
           },
+          awarding_institution: {
+            index: "('awarding_institution', :stored_searchable), link_to_search: solr_name('awarding_institution', :facetable)",
+            label: 'Awarding institution'
+          },
           based_near_label: {
             index: "('based_near_label', :stored_searchable), link_to_search: solr_name('based_near_label', :facetable)",
             schema_org: {
@@ -346,6 +350,10 @@ module DogBiscuits
           long: {
             index: "('long', :stored_searchable)",
             label: 'Longitude'
+          },
+          managing_organisation: {
+            index: "('managing_organisation', :stored_searchable)",
+            label: 'Managing organisation'
           },
           module_code: {
             index: "('module_code', :stored_searchable)",

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -154,5 +154,6 @@ FactoryBot.define do
     publication_status { ['Published'] }
     part_of { ['The Journal of Woe'] }
     managing_organisation { ['Managing Organisation'] }
+    funder { ['The National Parks Service'] }
   end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -134,6 +134,7 @@ FactoryBot.define do
     rights_description { ['some additional stuff about rights'] }
     source { ['tomato'] }
     subject { ['Official Heading for Woe'] }
+    awarding_institution { ['Awarding Institution'] }
   end
 
   factory :journal_article, class: JournalArticle do
@@ -152,5 +153,6 @@ FactoryBot.define do
     output_of { ['some project'] }
     publication_status { ['Published'] }
     part_of { ['The Journal of Woe'] }
+    managing_organisation { ['Managing Organisation'] }
   end
 end

--- a/spec/lib/models/authorities/person_spec.rb
+++ b/spec/lib/models/authorities/person_spec.rb
@@ -63,18 +63,4 @@ describe DogBiscuits::Person do
     stubby.add_pure_type
     expect(stubby.type).to include('http://dlib.york.ac.uk/ontologies/pure#Person')
   end
-
-  describe '#update usages for thesis' do
-    it 'thesis has creator' do
-      thesis.creator_resource << stubby
-      stubby.add_label
-      expect(thesis.to_solr['creator_label_tesim'].should(include(stubby.preflabel)))
-    end
-    #
-    it 'thesis does not have the creator after person is destroyed' do
-      stubby.destroy
-      thesis.reload
-      expect(thesis.to_solr['creator_label_tesim']).not_to include(stubby.preflabel)
-    end
-  end
 end

--- a/spec/lib/models/works/dataset_spec.rb
+++ b/spec/lib/models/works/dataset_spec.rb
@@ -43,13 +43,6 @@ describe Dataset do
   it_behaves_like 'simple_versions'
   it_behaves_like 'subtitle'
 
-  describe '#metadata' do
-    before do
-      stubby.managing_organisation_resource << org
-    end
-    specify { stubby.managing_organisation_resource.first.should eq(org) }
-  end
-
   describe '#rdftypes' do
     specify { stubby.type.should include('http://www.w3.org/ns/dcat#Dataset') }
     specify { stubby.type.should_not include('https://bib.schema.org/Thesis') }

--- a/spec/support/shared_example_access_provided_by_spec.rb
+++ b/spec/support/shared_example_access_provided_by_spec.rb
@@ -9,10 +9,6 @@ shared_examples_for 'access_provided_by' do
     expect(rdf.should(include('http://data.archiveshub.ac.uk/def/accessProvidedBy')))
   end
 
-  it 'has _label in solr' do
-    expect(stubby.to_solr['access_provided_by_label_tesim'].should(include('Rough Trade Records Archive')))
-  end
-
   it 'is in the solr_document' do
     expect(solr_doc.should(respond_to(:access_provided_by)))
   end
@@ -21,7 +17,6 @@ shared_examples_for 'access_provided_by' do
     expect(DogBiscuits.config.property_mappings[:access_provided_by].should(be_truthy))
   end
 
-  # TODO: label
   it 'is in the properties' do
     expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:access_provided_by)))
   end

--- a/spec/support/shared_example_advisor_spec.rb
+++ b/spec/support/shared_example_advisor_spec.rb
@@ -1,30 +1,13 @@
 # frozen_string_literal: true
 
 shared_examples_for 'advisor' do
-  let(:person) { FactoryBot.build_stubbed(:person) }
-
-  before do
-    person.add_label
-    stubby.advisor_resource << person
-  end
 
   it 'has advisor string' do
     expect(stubby.advisor).to eq(['Rourke, Andy'])
   end
 
-  it 'has advisor resource' do
-    expect(stubby.advisor_resource.first).to eq(person)
-  end
-
-  it 'has advisor resource predicate' do
-    expect(rdf.should(include('http://id.loc.gov/vocabulary/relators/ths')))
-  end
   it 'has advisor predicate' do
-    expect(rdf.should(include('http://dlib.york.ac.uk/ontologies/uketd#advisor')))
-  end
-
-  it 'has _label in solr' do
-    expect(stubby.to_solr['advisor_label_tesim'].should(include('Rourke, Andy', person.preflabel)))
+    expect(rdf.should(include('http://id.loc.gov/vocabulary/relators/ths')))
   end
 
   it 'has contributor in solr' do
@@ -40,7 +23,6 @@ shared_examples_for 'advisor' do
     expect(DogBiscuits.config.property_mappings[:advisor].should(be_truthy))
   end
 
-  # TODO: label
   it 'is in the properties' do
     expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:advisor)))
   end

--- a/spec/support/shared_example_advisor_spec.rb
+++ b/spec/support/shared_example_advisor_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples_for 'advisor' do
-
   it 'has advisor string' do
     expect(stubby.advisor).to eq(['Rourke, Andy'])
   end
@@ -11,7 +10,7 @@ shared_examples_for 'advisor' do
   end
 
   it 'has contributor in solr' do
-    expect(stubby.to_solr['contributor_combined_tesim'].should(include('Rourke, Andy', person.preflabel)))
+    expect(stubby.to_solr['contributor_combined_tesim'].should(include('Rourke, Andy')))
     expect(stubby.to_solr['contributor_type_sim'].should(include('advisor')))
   end
 

--- a/spec/support/shared_example_awarding_institution_spec.rb
+++ b/spec/support/shared_example_awarding_institution_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples_for 'awarding_institution' do
-
   it 'has awarding institution resource' do
     expect(stubby.awarding_institution).to eq(['Awarding Institution'])
   end
@@ -11,14 +10,14 @@ shared_examples_for 'awarding_institution' do
   end
 
   it 'is in the solr_document' do
-    expect(solr_doc.should respond_to(:awarding_institution))
+    expect(solr_doc.should(respond_to(:awarding_institution)))
   end
-  
+
   it 'is in the configuration property_mappings' do
-    expect(DogBiscuits.config.property_mappings[:awarding_institution].should be_truthy)
+    expect(DogBiscuits.config.property_mappings[:awarding_institution].should(be_truthy))
   end
-  
+
   it 'is in the properties' do
-    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:awarding_institution))
+    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:awarding_institution)))
   end
 end

--- a/spec/support/shared_example_awarding_institution_spec.rb
+++ b/spec/support/shared_example_awarding_institution_spec.rb
@@ -1,35 +1,24 @@
 # frozen_string_literal: true
 
 shared_examples_for 'awarding_institution' do
-  let(:org) { FactoryBot.build_stubbed(:organisation) }
-
-  before do
-    org.add_label
-    stubby.awarding_institution_resource << org
-  end
 
   it 'has awarding institution resource' do
-    expect(stubby.awarding_institution_resource.first).to eq(org)
+    expect(stubby.awarding_institution).to eq(['Awarding Institution'])
   end
 
-  it 'has will have an awarding institution predicate' do
+  it 'has an awarding institution predicate' do
     expect(rdf.should(include('http://id.loc.gov/ontologies/bibframe/grantingInstitution')))
   end
 
-  it 'has _label in solr' do
-    expect(stubby.to_solr['awarding_institution_label_tesim'].should(eq([org.preflabel])))
+  it 'is in the solr_document' do
+    expect(solr_doc.should respond_to(:awarding_institution))
   end
-
-  # TODO: awarding_institution
-  # it 'is in the solr_document' do
-  #   expect(solr_doc.should respond_to(:awarding_institution))
-  # end
-  #
-  # it 'is in the configuration property_mappings' do
-  #   expect(DogBiscuits.config.property_mappings[:awarding_institution].should be_truthy)
-  # end
-  #
-  # it 'is in the properties' do
-  #   expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:awarding_institution))
-  # end
+  
+  it 'is in the configuration property_mappings' do
+    expect(DogBiscuits.config.property_mappings[:awarding_institution].should be_truthy)
+  end
+  
+  it 'is in the properties' do
+    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:awarding_institution))
+  end
 end

--- a/spec/support/shared_example_contributor_spec.rb
+++ b/spec/support/shared_example_contributor_spec.rb
@@ -7,7 +7,7 @@ shared_examples_for 'contributor' do
   it 'has predicate' do
     expect(rdf.should(include('http://purl.org/dc/elements/1.1/contributor')))
   end
-  
+
   it 'is in the solr_document' do
     expect(solr_doc.should(respond_to(:contributor)))
   end

--- a/spec/support/shared_example_contributor_spec.rb
+++ b/spec/support/shared_example_contributor_spec.rb
@@ -1,24 +1,13 @@
 # frozen_string_literal: true
 
 shared_examples_for 'contributor' do
-  let(:contributor) { FactoryBot.build_stubbed(:person) }
-
-  before do
-    stubby.contributor_resource << contributor
-  end
   it 'has contributor' do
     expect(stubby.contributor).to eq(['Joyce, Mike'])
-  end
-  it 'has contributor resource' do
-    expect(stubby.contributor_resource.first).to eq(contributor)
   end
   it 'has predicate' do
     expect(rdf.should(include('http://purl.org/dc/elements/1.1/contributor')))
   end
-  it 'has resource predicate' do
-    expect(rdf.should(include('http://id.loc.gov/vocabulary/relators/ctb')))
-  end
-
+  
   it 'is in the solr_document' do
     expect(solr_doc.should(respond_to(:contributor)))
   end

--- a/spec/support/shared_example_creator_spec.rb
+++ b/spec/support/shared_example_creator_spec.rb
@@ -1,36 +1,12 @@
 # frozen_string_literal: true
 
 shared_examples_for 'creator' do
-  model_str = described_class.to_s.split('::')[1]
-
-  if model_str == 'ExamPaper'
-    let(:creator) { FactoryBot.build_stubbed(:organisation) }
-
-  else
-    let(:creator) { FactoryBot.build_stubbed(:person) }
-  end
-
-  before do
-    creator.add_label
-    stubby.creator_resource << creator
-  end
-
   it 'has creator' do
     expect(stubby.creator).to eq(['Marr, Johnny'])
-  end
-  it 'has creator resource' do
-    expect(stubby.creator_resource.first).to eq(creator)
   end
   it 'has predicate' do
     expect(rdf.should(include('http://purl.org/dc/elements/1.1/creator')))
   end
-  it 'has resource predicate' do
-    expect(rdf.should(include('http://id.loc.gov/vocabulary/relators/cre')))
-  end
-  it 'has _label in solr' do
-    expect(stubby.to_solr['creator_label_tesim'].should(include('Marr, Johnny', creator.preflabel)))
-  end
-
   it 'is in the solr_document' do
     expect(solr_doc.should(respond_to(:creator)))
   end
@@ -39,7 +15,6 @@ shared_examples_for 'creator' do
     expect(DogBiscuits.config.property_mappings[:creator].should(be_truthy))
   end
 
-  # TODO: label
   it 'is in the properties' do
     expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:creator)))
   end

--- a/spec/support/shared_example_department_spec.rb
+++ b/spec/support/shared_example_department_spec.rb
@@ -1,24 +1,12 @@
 # frozen_string_literal: true
 
 shared_examples_for 'department' do
-  let(:org) { FactoryBot.build_stubbed(:organisation) }
-
-  before do
-    stubby.department_resource << org
-  end
-  # metadata
   it 'has department' do
-    expect(stubby.department_resource.first).to eq(org)
     expect(stubby.department).to eq(['Departmtent of Worry and Woe'])
   end
 
   it 'has department predicate' do
-    expect(rdf.should(include('http://dlib.york.ac.uk/ontologies/uketd#departmentResource')))
     expect(rdf.should(include('http://schema.org/department')))
-  end
-
-  it 'has _label in solr' do
-    expect(stubby.to_solr['department_label_tesim'].should(eq([org.preflabel])))
   end
 
   it 'is in the solr_document' do

--- a/spec/support/shared_example_editor_spec.rb
+++ b/spec/support/shared_example_editor_spec.rb
@@ -1,29 +1,12 @@
 # frozen_string_literal: true
 
 shared_examples_for 'editor' do
-  let(:person) { FactoryBot.build_stubbed(:person) }
-  before do
-    person.add_label
-    stubby.editor_resource << person
-  end
-
   it 'has editor string' do
     expect(stubby.editor).to eq(['Street, Stephen'])
   end
 
-  it 'has editor resource' do
-    expect(stubby.editor_resource.first).to eq(person)
-  end
-
-  it 'has editor resource predicate' do
-    expect(rdf.should(include('http://id.loc.gov/vocabulary/relators/edc')))
-  end
   it 'has editor predicate' do
-    expect(rdf.should(include('http://purl.org/ontology/bibo/editor')))
-  end
-
-  it 'has _label in solr' do
-    expect(stubby.to_solr['editor_label_tesim'].should(include('Street, Stephen', person.preflabel)))
+    expect(rdf.should(include('http://id.loc.gov/vocabulary/relators/edc')))
   end
 
   it 'has contributor in solr' do
@@ -39,7 +22,6 @@ shared_examples_for 'editor' do
     expect(DogBiscuits.config.property_mappings[:editor].should(be_truthy))
   end
 
-  # TODO: label
   it 'is in the properties' do
     expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:editor)))
   end

--- a/spec/support/shared_example_editor_spec.rb
+++ b/spec/support/shared_example_editor_spec.rb
@@ -10,7 +10,7 @@ shared_examples_for 'editor' do
   end
 
   it 'has contributor in solr' do
-    expect(stubby.to_solr['contributor_combined_tesim'].should(include('Street, Stephen', person.preflabel)))
+    expect(stubby.to_solr['contributor_combined_tesim'].should(include('Street, Stephen')))
     expect(stubby.to_solr['contributor_type_sim'].should(include('editor')))
   end
 

--- a/spec/support/shared_example_funder_spec.rb
+++ b/spec/support/shared_example_funder_spec.rb
@@ -13,14 +13,14 @@ shared_examples_for 'funder' do
     expect(stubby.to_solr['contributor_type_sim'].should(include('funder')))
   end
   it 'is in the solr_document' do
-    expect(solr_doc.should respond_to(:funder))
+    expect(solr_doc.should(respond_to(:funder)))
   end
-  
+
   it 'is in the configuration property_mappings' do
-    expect(DogBiscuits.config.property_mappings[:funder].should be_truthy)
+    expect(DogBiscuits.config.property_mappings[:funder].should(be_truthy))
   end
-  
+
   it 'is in the properties' do
-    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:funder))
+    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:funder)))
   end
 end

--- a/spec/support/shared_example_funder_spec.rb
+++ b/spec/support/shared_example_funder_spec.rb
@@ -1,33 +1,26 @@
 # frozen_string_literal: true
 
 shared_examples_for 'funder' do
-  let(:funder) { FactoryBot.build_stubbed(:organisation) }
-
-  before do
-    stubby.funder_resource << funder
-  end
   it 'has funder' do
-    expect(stubby.funder_resource.first).to eq(funder)
+    expect(stubby.funder).to eq(['The National Parks Service'])
   end
   it 'has funder predicate' do
     expect(rdf.should(include('http://id.loc.gov/vocabulary/relators/fnd')))
   end
 
-  # TODO: funder
-
-  # it 'has contributor in solr' do
-  #   expect(stubby.to_solr['contributor_combined_tesim'].should(include(funder.preflabel)))
-  #   expect(stubby.to_solr['contributor_type_sim'].should(include('editor')))
-  # end
-  # it 'is in the solr_document' do
-  #   expect(solr_doc.should respond_to(:funder))
-  # end
-  #
-  # it 'is in the configuration property_mappings' do
-  #   expect(DogBiscuits.config.property_mappings[:funder].should be_truthy)
-  # end
-  #
-  # it 'is in the properties' do
-  #   expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:funder))
-  # end
+  it 'has contributor in solr' do
+    expect(stubby.to_solr['contributor_combined_tesim'].should(include('The National Parks Service')))
+    expect(stubby.to_solr['contributor_type_sim'].should(include('funder')))
+  end
+  it 'is in the solr_document' do
+    expect(solr_doc.should respond_to(:funder))
+  end
+  
+  it 'is in the configuration property_mappings' do
+    expect(DogBiscuits.config.property_mappings[:funder].should be_truthy)
+  end
+  
+  it 'is in the properties' do
+    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:funder))
+  end
 end

--- a/spec/support/shared_example_managing_organisation_spec.rb
+++ b/spec/support/shared_example_managing_organisation_spec.rb
@@ -1,32 +1,23 @@
 # frozen_string_literal: true
 
 shared_examples_for 'managing_organisation' do
-  let(:org) { FactoryBot.build(:organisation) }
-
-  before do
-    stubby.managing_organisation_resource << org
-  end
+  
   it 'has managing organisation' do
-    expect(stubby.managing_organisation_resource.first).to eq(org)
+    expect(stubby.managing_organisation).to eq(['Managing Organisation'])
   end
   it 'has managing organisation predicate' do
     expect(rdf.should(include('http://dlib.york.ac.uk/ontologies/pure#pureManagingUnit')))
   end
 
-  it 'has _label in solr' do
-    expect(stubby.to_solr['managing_organisation_label_tesim'].should(eq([org.preflabel])))
+  it 'is in the solr_document' do
+    expect(solr_doc.should respond_to(:managing_organisation))
   end
-
-  # TODO: managing_organisation
-  # it 'is in the solr_document' do
-  #   expect(solr_doc.should respond_to(:abstract))
-  # end
-  #
-  # it 'is in the configuration property_mappings' do
-  #   expect(DogBiscuits.config.property_mappings[:abstract].should be_truthy)
-  # end
-  #
-  # it 'is in the properties' do
-  #   expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:abstract))
-  # end
+  
+  it 'is in the configuration property_mappings' do
+    expect(DogBiscuits.config.property_mappings[:managing_organisation].should be_truthy)
+  end
+  
+  it 'is in the properties' do
+    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:managing_organisation))
+  end
 end

--- a/spec/support/shared_example_managing_organisation_spec.rb
+++ b/spec/support/shared_example_managing_organisation_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples_for 'managing_organisation' do
-  
   it 'has managing organisation' do
     expect(stubby.managing_organisation).to eq(['Managing Organisation'])
   end
@@ -10,14 +9,14 @@ shared_examples_for 'managing_organisation' do
   end
 
   it 'is in the solr_document' do
-    expect(solr_doc.should respond_to(:managing_organisation))
+    expect(solr_doc.should(respond_to(:managing_organisation)))
   end
-  
+
   it 'is in the configuration property_mappings' do
-    expect(DogBiscuits.config.property_mappings[:managing_organisation].should be_truthy)
+    expect(DogBiscuits.config.property_mappings[:managing_organisation].should(be_truthy))
   end
-  
+
   it 'is in the properties' do
-    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should include(:managing_organisation))
+    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:managing_organisation)))
   end
 end

--- a/spec/support/shared_example_output_of_spec.rb
+++ b/spec/support/shared_example_output_of_spec.rb
@@ -1,22 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples_for 'output_of' do
-  let(:project) { FactoryBot.build_stubbed(:project) }
-
-  before do
-    stubby.output_of_resource << project
-  end
-  it 'has project' do
-    expect(stubby.output_of_resource.first).to eq(project)
-  end
-  it 'has project predicate' do
-    expect(rdf.should(include('http://london.ac.uk/ontologies/terms#outputOf')))
-  end
-
-  it 'has _label in solr' do
-    expect(stubby.to_solr.should(include('output_of_label_tesim')))
-  end
-
   it 'has output_of' do
     expect(stubby.output_of).to eq(['some project'])
   end
@@ -33,6 +17,6 @@ shared_examples_for 'output_of' do
   end
 
   it 'is in the properties' do
-    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:abstract)))
+    expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:output_of)))
   end
 end

--- a/spec/support/shared_example_presented_at_spec.rb
+++ b/spec/support/shared_example_presented_at_spec.rb
@@ -4,7 +4,7 @@ shared_examples_for 'presented_at' do
   it 'has conference' do
     expect(stubby.presented_at).to eq(['The International Conference of Misery'])
   end
-  
+
   it 'has presented at predicate' do
     expect(rdf.should(include('http://purl.org/ontology/bibo/presentedAt')))
   end

--- a/spec/support/shared_example_presented_at_spec.rb
+++ b/spec/support/shared_example_presented_at_spec.rb
@@ -1,25 +1,12 @@
 # frozen_string_literal: true
 
 shared_examples_for 'presented_at' do
-  let(:conference) { FactoryBot.build_stubbed(:event) }
-
-  before do
-    conference.add_label
-    stubby.presented_at_resource << conference
-  end
   it 'has conference' do
     expect(stubby.presented_at).to eq(['The International Conference of Misery'])
   end
-  it 'has conference resource' do
-    expect(stubby.presented_at_resource).to eq([conference])
-  end
+  
   it 'has presented at predicate' do
     expect(rdf.should(include('http://purl.org/ontology/bibo/presentedAt')))
-    expect(rdf.should(include('http://london.ac.uk/ontologies/terms#presentedAtConference')))
-  end
-
-  it 'has _label in solr' do
-    expect(stubby.to_solr['presented_at_label_tesim'].should(include('The International Conference of Misery', conference.preflabel)))
   end
 
   it 'is in the solr_document' do
@@ -30,7 +17,6 @@ shared_examples_for 'presented_at' do
     expect(DogBiscuits.config.property_mappings[:presented_at].should(be_truthy))
   end
 
-  # TODO: label
   it 'is in the properties' do
     expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:presented_at)))
   end

--- a/spec/support/shared_example_publisher_spec.rb
+++ b/spec/support/shared_example_publisher_spec.rb
@@ -1,36 +1,19 @@
 # frozen_string_literal: true
 
 shared_examples_for 'publisher' do
-  let(:publisher) { FactoryBot.build(:organisation) }
-
-  before do
-    stubby.publisher_resource << publisher
-  end
+  
   it 'has publisher' do
     expect(stubby.publisher).to eq(['Rough Trade Records'])
-  end
-  it 'has publisher resource' do
-    expect(stubby.publisher_resource.first).to eq(publisher)
   end
   it 'has publisher predicate' do
     expect(rdf.should(include('http://purl.org/dc/elements/1.1/publisher')))
   end
-  it 'has pbl predicate' do
-    expect(rdf.should(include('http://id.loc.gov/vocabulary/relators/pbl')))
-  end
-  it 'has _label in solr' do
-    expect(stubby.to_solr.should(include('publisher_label_tesim')))
-  end
-
   it 'is in the solr_document' do
     expect(solr_doc.should(respond_to(:publisher)))
   end
-
   it 'is in the configuration property_mappings' do
     expect(DogBiscuits.config.property_mappings[:publisher].should(be_truthy))
   end
-
-  # TODO: label
   it 'is in the properties' do
     expect(DogBiscuits.config.send("#{stubby.class.to_s.underscore}_properties").should(include(:publisher)))
   end

--- a/spec/support/shared_example_publisher_spec.rb
+++ b/spec/support/shared_example_publisher_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples_for 'publisher' do
-  
   it 'has publisher' do
     expect(stubby.publisher).to eq(['Rough Trade Records'])
   end

--- a/spec/support/shared_example_subject_spec.rb
+++ b/spec/support/shared_example_subject_spec.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 shared_examples_for 'subject' do
-  
   it 'has subject (external)' do
     expect(stubby.subject).to eq(['Official Heading for Woe'])
   end
   it 'has dc11 subject predicate' do
     expect(rdf.should(include('http://purl.org/dc/elements/1.1/subject')))
   end
-  
+
   it 'is in the solr_document' do
     expect(solr_doc.should(respond_to(:subject)))
   end

--- a/spec/support/shared_example_subject_spec.rb
+++ b/spec/support/shared_example_subject_spec.rb
@@ -1,25 +1,14 @@
 # frozen_string_literal: true
 
 shared_examples_for 'subject' do
-  # let(:sub) { FactoryBot.build_stubbed(:simple_concept) }
-
-  # before do
-  #   stubby.subject_resource << sub
-  # end
-  # it 'has subject (internal object)' do
-  #   expect(stubby.subject_resource.first).to eq(sub)
-  # end
+  
   it 'has subject (external)' do
     expect(stubby.subject).to eq(['Official Heading for Woe'])
   end
-  # it 'has dc subject predicate' do
-  #   expect(rdf.should(include('http://purl.org/dc/terms/subject')))
-  # end
   it 'has dc11 subject predicate' do
     expect(rdf.should(include('http://purl.org/dc/elements/1.1/subject')))
   end
-  # TODO: Test for _label in solr when models use it
-
+  
   it 'is in the solr_document' do
     expect(solr_doc.should(respond_to(:subject)))
   end


### PR DESCRIPTION
This PR removes quite a lot of code designed to support using fedora-based authorities as has_and_belongs_to_many relations on samvera models. On reflection, the code is over-complex and leads to various issues, such as needing two predicates to support 'normal' properties and has_and_belongs_to_many. 

Further work on better integrating controlled properties should be done. 