### PR TITLE
use saassc for rails versions above 4.2 in engine_cart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ else
   when /^4.2/
     gem 'coffee-rails', '~> 4.1.0'
     gem 'responders', '~> 2.0'
-    gem 'sass-rails', '>= 5.0'
+    gem 'sassc'
   when /^4.[01]/
     gem 'sass-rails', '< 5.0'
   end


### PR DESCRIPTION
rails-sass will be deprecated next March.