### PR TITLE
fixes #145

### DIFF
--- a/lib/generators/dog_biscuits/generate_all_generator.rb
+++ b/lib/generators/dog_biscuits/generate_all_generator.rb
@@ -16,6 +16,10 @@ This generator makes the following changes to your application:
   def banner
     say_status("info", "Re-generating catalog_controller, locales, attribute_rows and schema_org", :blue)
   end
+  
+  def create_indexers
+    directory 'app/indexers', 'app/indexers'
+  end
 
   def generate_works
     DogBiscuits.config.selected_models.each do |model|

--- a/lib/generators/dog_biscuits/work/work_generator.rb
+++ b/lib/generators/dog_biscuits/work/work_generator.rb
@@ -63,16 +63,10 @@ This generator makes the following changes to your application:
 
   def create_form
     template('form.rb.erb', File.join('app/forms/hyrax', class_path, "#{file_name}_form.rb"))
-  rescue NameError
-    create_indexer
-    create_form
   end
 
   def create_presenter
     template('presenter.rb.erb', File.join('app/presenters/hyrax', class_path, "#{file_name}_presenter.rb"))
-  rescue NameError
-    create_indexer
-    create_presenter
   end
 
   def create_actor


### PR DESCRIPTION
Fixes long standing issue where the first work to be generated by the generate_all generator would fail with a NameError. Problem was the creation of the 'indexers' folder. By creating this in advance with a .keep file, we seem to avoid this issue.