### PR TITLE
Fix NameError on first run of work generator

### DIFF
--- a/lib/generators/dog_biscuits/presenter/presenter_generator.rb
+++ b/lib/generators/dog_biscuits/presenter/presenter_generator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails/generators'
+require 'rails/generators/model_helpers'
+
+class DogBiscuits::PresenterGenerator < Rails::Generators::NamedBase
+  include Rails::Generators::ModelHelpers
+  source_root File.expand_path('../../work/templates', __FILE__)
+
+  desc '
+This generator makes the following changes to your application:
+    The DogBiscuits Presenter generator makes the following changes to your application:
+    1. Creates the presenter
+       '
+
+  def banner
+    say_status("info", "Creating presenter for: #{class_name}", :blue)
+  end
+
+  # This is in a separate generator to try and get round the NameError on first run
+  #   caused when calling constantize on class_name (ie. the model class) in the template
+  def presenter_template
+    template('presenter.rb.erb', File.join('app/presenters/hyrax', class_path, "#{file_name}_presenter.rb"))
+    rescue NameError => e
+      say_status("error", e.message, :red)
+  end
+end

--- a/lib/generators/dog_biscuits/work/work_generator.rb
+++ b/lib/generators/dog_biscuits/work/work_generator.rb
@@ -44,7 +44,11 @@ This generator makes the following changes to your application:
     say_status("info", "RUNNING rails generate hyrax:work #{class_name}", :blue)
     generate "hyrax:work #{class_name}", '-f'
   end
-
+  
+  def create_actor
+    template('actor.rb.erb', File.join('app/actors/hyrax/actors', class_path, "#{file_name}_actor.rb"))
+  end
+  
   def create_indexer
     if options[:skipmodel]
       say_status("info", "SKIPPING INDEXER GENERATION", :blue)
@@ -52,7 +56,7 @@ This generator makes the following changes to your application:
       template('indexer.rb.erb', File.join('app/indexers', class_path, "#{file_name}_indexer.rb"))
     end
   end
-
+  
   def create_model
     if options[:skipmodel]
       say_status("info", "SKIPPING MODEL GENERATION", :blue)
@@ -60,15 +64,15 @@ This generator makes the following changes to your application:
       template('model.rb.erb', File.join('app/models/', class_path, "#{file_name}.rb"))
     end
   end
-
+  
+  def create_form
+    template('form.rb.erb', File.join('app/forms/hyrax', class_path, "#{file_name}_form.rb"))
+  end
+  
   def create_presenter
-    template('presenter.rb.erb', File.join('app/presenters/hyrax', class_path, "#{file_name}_presenter.rb"))
+    generate "dog_biscuits:presenter #{class_name}", '-f'
   end
-
-  def create_actor
-    template('actor.rb.erb', File.join('app/actors/hyrax/actors', class_path, "#{file_name}_actor.rb"))
-  end
-
+  
   def create_attribute_rows
     attributes_file = "app/views/hyrax/#{file_name.pluralize}/_attribute_rows.html.erb"
     copy_file '_attribute_rows.html.erb', attributes_file
@@ -84,12 +88,6 @@ This generator makes the following changes to your application:
 
   def imagify
     generate "dog_biscuits:imagify #{class_name}", '-f' if File.exist?('config/initializers/version.rb') && File.read('config/initializers/version.rb').include?('Hyku')
-  end
-  
-  # Sometimes we see a name error NameError because *_form.rb references the Model which hasn't yet been loaded
-  #  rescue doesn't help, so run this last to ensure files are all in place before the error
-  def create_form
-    template('form.rb.erb', File.join('app/forms/hyrax', class_path, "#{file_name}_form.rb"))
   end
 
   def display_readme


### PR DESCRIPTION
This has been a really difficult one to track down, and I'm not 100% convinced this solution will work consistently.

The issue seems to be that the presenter template calls constantize on the model class. This causes a `NameError` (uninitialized constant) error on first run presumably because although the model is in place, the app hasn't loaded it yet.

This PR moves the presenter template step into a separate generator, tests so far have been successful.